### PR TITLE
Add missing cast to `double` in `mySecond`

### DIFF
--- a/raiderstream/include/RaiderSTREAM/RSBaseImpl.h
+++ b/raiderstream/include/RaiderSTREAM/RSBaseImpl.h
@@ -139,7 +139,7 @@ public:
   }
 
   double mySecond() {
-    return cpu_cycles()/CYCLES_PER_SEC;
+    return (static_cast <double> (cpu_cycles()))/CYCLES_PER_SEC;
   }
 
   int checkTick() {


### PR DESCRIPTION
Ensure the division is performed as floating point.